### PR TITLE
Add minimal Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,3 +412,14 @@ Copyright (c) 2012-2025 Ciro Mattia Gonano, Paweł Jastrzębski, Darodi and Alex
 
 ## Verification
 Impact-Site-Verification: ffe48fc7-4f0c-40fd-bd2e-59f4d7205180
+
+## WEB INTERFACE
+A minimal Flask application is available in `webapp/app.py` for running KCC through a browser.
+After installing the dependencies, start the server with:
+
+```bash
+pip install -r requirements.txt
+python3 webapp/app.py
+```
+
+The application listens on port `5000`. Upload a comic archive or PDF and the converted file will be offered for download. This script can be deployed on any standard Python host such as Hostinger.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ natsort>=8.4.0
 distro>=1.8.0
 numpy>=1.22.4
 PyMuPDF>=1.26.1
+Flask>=3.0.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,35 @@
+import os
+import subprocess
+import tempfile
+from flask import Flask, request, send_file, render_template
+from werkzeug.utils import secure_filename
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        uploaded = request.files.get('file')
+        fmt = request.form.get('format', 'CBZ')
+        if not uploaded or uploaded.filename == '':
+            return 'No file uploaded', 400
+        filename = secure_filename(uploaded.filename)
+        src_path = os.path.join(UPLOAD_FOLDER, filename)
+        uploaded.save(src_path)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = ['python3', os.path.join(ROOT_DIR, 'kcc-c2e.py'), '-f', fmt, '-o', tmpdir, src_path]
+            result = subprocess.run(cmd, capture_output=True)
+            if result.returncode != 0:
+                return 'Conversion failed', 500
+            files = os.listdir(tmpdir)
+            if not files:
+                return 'Conversion failed', 500
+            return send_file(os.path.join(tmpdir, files[0]), as_attachment=True)
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Kindle Comic Converter Web</title>
+</head>
+<body>
+    <h1>Kindle Comic Converter Web</h1>
+    <form action="/" method="post" enctype="multipart/form-data">
+        <label for="file">Comic archive/PDF:</label>
+        <input type="file" name="file" id="file" required>
+        <label for="format">Output format:</label>
+        <select name="format" id="format">
+            <option value="CBZ">CBZ</option>
+            <option value="EPUB">EPUB</option>
+            <option value="MOBI">MOBI</option>
+        </select>
+        <button type="submit">Convert</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a simple web interface for converting comics with KCC
- document how to run the web app
- add Flask as a dependency

## Testing
- `pip install -r requirements.txt`
- `pip install Flask`
- `python3 webapp/app.py` (server started)


------
https://chatgpt.com/codex/tasks/task_e_68811d561790832fb98595f22b74163f