### PR TITLE
Add Tailwind UI with full CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,3 +412,15 @@ Copyright (c) 2012-2025 Ciro Mattia Gonano, Paweł Jastrzębski, Darodi and Alex
 
 ## Verification
 Impact-Site-Verification: ffe48fc7-4f0c-40fd-bd2e-59f4d7205180
+
+## WEB INTERFACE
+A Flask application is available in `webapp/app.py` for running KCC through a browser.
+The HTML interface is styled with [Tailwind CSS](https://tailwindcss.com/) and exposes
+all command line options. After installing the dependencies, start the server with:
+
+```bash
+pip install -r requirements.txt
+python3 webapp/app.py
+```
+
+The application listens on port `5000`. Upload a comic archive or PDF and the converted file will be offered for download. This script can be deployed on any standard Python host such as Hostinger.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ natsort>=8.4.0
 distro>=1.8.0
 numpy>=1.22.4
 PyMuPDF>=1.26.1
+Flask>=3.0.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,97 @@
+import os
+import subprocess
+import tempfile
+from flask import Flask, request, send_file, render_template
+from werkzeug.utils import secure_filename
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+app = Flask(__name__)
+
+OPTIONS = {
+    'profile': ('-p', False),
+    'manga_style': ('-m', True),
+    'hq': ('-q', True),
+    'two_panel': ('-2', True),
+    'webtoon': ('-w', True),
+    'targetsize': ('--ts', False),
+    'title': ('-t', False),
+    'comicinfotitle': ('--comicinfotitle', True),
+    'author': ('-a', False),
+    'format': ('-f', False),
+    'nokepub': ('--nokepub', True),
+    'batchsplit': ('-b', False),
+    'spreadshift': ('--spreadshift', True),
+    'norotate': ('--norotate', True),
+    'rotatefirst': ('--rotatefirst', True),
+    'noprocessing': ('-n', True),
+    'upscale': ('-u', True),
+    'stretch': ('-s', True),
+    'splitter': ('-r', False),
+    'gamma': ('-g', False),
+    'autolevel': ('--autolevel', True),
+    'cropping': ('-c', False),
+    'croppingpower': ('--cp', False),
+    'preservemargin': ('--preservemargin', False),
+    'croppingminimum': ('--cm', False),
+    'interpanelcrop': ('--ipc', False),
+    'blackborders': ('--blackborders', True),
+    'whiteborders': ('--whiteborders', True),
+    'forcecolor': ('--forcecolor', True),
+    'eraserainbow': ('--eraserainbow', True),
+    'forcepng': ('--forcepng', True),
+    'mozjpeg': ('--mozjpeg', True),
+    'maximizestrips': ('--maximizestrips', True),
+    'delete': ('-d', True),
+    'customwidth': ('--customwidth', False),
+    'customheight': ('--customheight', False),
+}
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        uploaded = request.files.get('file')
+        if not uploaded or uploaded.filename == '':
+            return 'No file uploaded', 400
+        filename = secure_filename(uploaded.filename)
+        src_path = os.path.join(UPLOAD_FOLDER, filename)
+        uploaded.save(src_path)
+        out_option = request.form.get('output')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = ['python3', os.path.join(ROOT_DIR, 'kcc-c2e.py')]
+            for field, (flag, is_flag) in OPTIONS.items():
+                value = request.form.get(field)
+                if value is None or value == '':
+                    continue
+                if is_flag:
+                    cmd.append(flag)
+                else:
+                    cmd.extend([flag, value])
+            if out_option:
+                cmd.extend(['-o', out_option])
+            else:
+                cmd.extend(['-o', tmpdir])
+            cmd.append(src_path)
+            result = subprocess.run(cmd, capture_output=True)
+            if result.returncode != 0:
+                return 'Conversion failed', 500
+            if out_option:
+                if os.path.isdir(out_option):
+                    files = os.listdir(out_option)
+                    if not files:
+                        return 'Conversion failed', 500
+                    out_path = os.path.join(out_option, files[0])
+                else:
+                    out_path = out_option
+            else:
+                files = os.listdir(tmpdir)
+                if not files:
+                    return 'Conversion failed', 500
+                out_path = os.path.join(tmpdir, files[0])
+            return send_file(out_path, as_attachment=True)
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Kindle Comic Converter Web</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100 p-4">
+<div class="container mx-auto">
+    <h1 class="text-2xl font-bold mb-4">Kindle Comic Converter Web</h1>
+    <form action="/" method="post" enctype="multipart/form-data" class="space-y-4 bg-white p-4 rounded shadow">
+        <div>
+            <label class="block font-semibold">Comic archive/PDF</label>
+            <input type="file" name="file" required class="mt-1 border p-2 w-full" />
+        </div>
+        <div>
+            <label class="block font-semibold">Profile</label>
+            <input type="text" name="profile" placeholder="KV" class="mt-1 border p-2 w-full" />
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <label><input type="checkbox" name="manga_style" class="mr-1">Manga style</label>
+            <label><input type="checkbox" name="hq" class="mr-1">HQ</label>
+            <label><input type="checkbox" name="two_panel" class="mr-1">Two panel</label>
+            <label><input type="checkbox" name="webtoon" class="mr-1">Webtoon</label>
+            <label><input type="checkbox" name="comicinfotitle" class="mr-1">Use ComicInfo title</label>
+            <label><input type="checkbox" name="nokepub" class="mr-1">No Kepub</label>
+            <label><input type="checkbox" name="spreadshift" class="mr-1">Spread shift</label>
+            <label><input type="checkbox" name="norotate" class="mr-1">No rotate</label>
+            <label><input type="checkbox" name="rotatefirst" class="mr-1">Rotate first</label>
+            <label><input type="checkbox" name="noprocessing" class="mr-1">No processing</label>
+            <label><input type="checkbox" name="upscale" class="mr-1">Upscale</label>
+            <label><input type="checkbox" name="stretch" class="mr-1">Stretch</label>
+            <label><input type="checkbox" name="autolevel" class="mr-1">Auto level</label>
+            <label><input type="checkbox" name="blackborders" class="mr-1">Black borders</label>
+            <label><input type="checkbox" name="whiteborders" class="mr-1">White borders</label>
+            <label><input type="checkbox" name="forcecolor" class="mr-1">Force color</label>
+            <label><input type="checkbox" name="eraserainbow" class="mr-1">Erase rainbow</label>
+            <label><input type="checkbox" name="forcepng" class="mr-1">Force PNG</label>
+            <label><input type="checkbox" name="mozjpeg" class="mr-1">MozJPEG</label>
+            <label><input type="checkbox" name="maximizestrips" class="mr-1">Maximize strips</label>
+            <label><input type="checkbox" name="delete" class="mr-1">Delete source</label>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block font-semibold">Target size MB</label>
+                <input type="number" name="targetsize" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Output directory</label>
+                <input type="text" name="output" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Title</label>
+                <input type="text" name="title" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Author</label>
+                <input type="text" name="author" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Format</label>
+                <select name="format" class="mt-1 border p-2 w-full">
+                    <option value="Auto">Auto</option>
+                    <option value="CBZ">CBZ</option>
+                    <option value="EPUB">EPUB</option>
+                    <option value="MOBI">MOBI</option>
+                    <option value="KFX">KFX</option>
+                    <option value="MOBI+EPUB">MOBI+EPUB</option>
+                </select>
+            </div>
+            <div>
+                <label class="block font-semibold">Batch split</label>
+                <input type="number" name="batchsplit" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Splitter mode</label>
+                <input type="number" name="splitter" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Gamma</label>
+                <input type="number" step="0.1" name="gamma" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Cropping mode</label>
+                <input type="number" name="cropping" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Cropping power</label>
+                <input type="number" step="0.1" name="croppingpower" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Preserve margin %</label>
+                <input type="number" step="0.1" name="preservemargin" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Cropping minimum</label>
+                <input type="number" step="0.1" name="croppingminimum" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Interpanel crop</label>
+                <input type="number" name="interpanelcrop" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Custom width</label>
+                <input type="number" name="customwidth" class="mt-1 border p-2 w-full" />
+            </div>
+            <div>
+                <label class="block font-semibold">Custom height</label>
+                <input type="number" name="customheight" class="mt-1 border p-2 w-full" />
+            </div>
+        </div>
+        <div>
+            <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Convert</button>
+        </div>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- style the web interface with Tailwind CSS
- expose every command line option in the HTML form
- update Flask app to map all form fields to KCC options
- document the improved web app

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile webapp/app.py`
- `python3 webapp/app.py` *(server started)*


------
https://chatgpt.com/codex/tasks/task_e_68811d561790832fb98595f22b74163f